### PR TITLE
Make AnimGif compatible with PHP 8's GdImage class

### DIFF
--- a/src/GifCreator/AnimGif.php
+++ b/src/GifCreator/AnimGif.php
@@ -160,7 +160,7 @@ class AnimGif
 
 		$i = 0;
 		foreach ($frames as $frame) {
-			if (is_resource($frame)) { // in-memory image resource (hopefully)
+			if (is_resource($frame) || $frame instanceof \GdImage) { // in-memory image resource (hopefully)
 
 				$resourceImg = $frame;
 


### PR DESCRIPTION
`is_resource` returns `false` for GdImage objects since PHP 8.0, this fixes the check if the supplied frame is a resource.